### PR TITLE
update baudrate to baudRate

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ Mindwave.prototype.connect = function(port, baud){
 	// http://developer.neurosky.com/docs/doku.php?id=thinkgear_communications_protocol#thinkgear_command_bytes
 
 	self.serialPort = new SerialPort(self.port, {
-    baudrate: self.baud,
+    baudRate: self.baud,
     autoOpen: false,
   });
 	self.serialPort.open(function(){


### PR DESCRIPTION
In serialport >7.0.2, 'baudrate' is referred to as 'baudRate'.  Updated index.js.